### PR TITLE
Nav bar addition

### DIFF
--- a/lib/Views/appSettings.dart
+++ b/lib/Views/appSettings.dart
@@ -11,40 +11,63 @@ class AppSettings extends StatelessWidget {
       appBar: AppBar(title: const Text('App Settings')),
       body: Center(
         child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
+          mainAxisAlignment: MainAxisAlignment.start,
+          crossAxisAlignment: CrossAxisAlignment.end,
           children: <Widget>[
-            const Text(
-              'App Settings',
-              style: TextStyle(fontSize: 40),
-            ),
             const SizedBox(height: 30),
             const Text(
               'Setting 1',
               style: TextStyle(fontSize: 20),
             ),
+            const SettingSwitch(title: "Setting 1"),
             const SizedBox(height: 30),
             const Text(
               'Setting 2',
               style: TextStyle(fontSize: 20),
             ),
+            const SettingSwitch(title: "Setting 2"),
             const SizedBox(height: 30),
             const Text(
               'Setting 3',
               style: TextStyle(fontSize: 20),
             ),
+            const SettingSwitch(title: "Setting 3"),
             const SizedBox(height: 30),
             const Text(
               'Setting 4',
               style: TextStyle(fontSize: 20),
             ),
-            const SizedBox(height: 30),
-            const Text(
-              'Setting 5',
-              style: TextStyle(fontSize: 20),
-            ),
+            const SettingSwitch(title: "Setting 4"),
           ],
         ),
       ),
+    );
+  }
+}
+
+//Quick widget for a setting switch
+//Takes in a title
+
+class SettingSwitch extends StatefulWidget {
+  final String title;
+  const SettingSwitch({Key? key, required this.title}) : super(key: key);
+
+  @override
+  _SettingSwitchState createState() => _SettingSwitchState();
+}
+
+class _SettingSwitchState extends State<SettingSwitch> {
+  bool _value = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Switch(
+      value: _value,
+      onChanged: (value) {
+        setState(() {
+          _value = value;
+        });
+      },
     );
   }
 }

--- a/lib/Views/appSettings.dart
+++ b/lib/Views/appSettings.dart
@@ -1,0 +1,50 @@
+//Simple skeleton view for the app settings page
+
+import 'package:flutter/material.dart';
+
+class AppSettings extends StatelessWidget {
+  const AppSettings({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('App Settings')),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            const Text(
+              'App Settings',
+              style: TextStyle(fontSize: 40),
+            ),
+            const SizedBox(height: 30),
+            const Text(
+              'Setting 1',
+              style: TextStyle(fontSize: 20),
+            ),
+            const SizedBox(height: 30),
+            const Text(
+              'Setting 2',
+              style: TextStyle(fontSize: 20),
+            ),
+            const SizedBox(height: 30),
+            const Text(
+              'Setting 3',
+              style: TextStyle(fontSize: 20),
+            ),
+            const SizedBox(height: 30),
+            const Text(
+              'Setting 4',
+              style: TextStyle(fontSize: 20),
+            ),
+            const SizedBox(height: 30),
+            const Text(
+              'Setting 5',
+              style: TextStyle(fontSize: 20),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/Views/myChats.dart
+++ b/lib/Views/myChats.dart
@@ -1,0 +1,53 @@
+//View for the user's chats
+//Will display in recent order, as well as a search bar to search for specific chats
+
+import 'package:flutter/material.dart';
+import 'package:roommatch/Widgets/navBar.dart';
+
+class MyChats extends StatelessWidget {
+  const MyChats({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      //appBar: AppBar(title: const Text('My Chats')),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            const Text(
+              'My Chats',
+              style: TextStyle(fontSize: 40),
+            ),
+            const SizedBox(height: 30),
+            const Text(
+              'Chat 1',
+              style: TextStyle(fontSize: 20),
+            ),
+            const SizedBox(height: 30),
+            const Text(
+              'Chat 2',
+              style: TextStyle(fontSize: 20),
+            ),
+            const SizedBox(height: 30),
+            const Text(
+              'Chat 3',
+              style: TextStyle(fontSize: 20),
+            ),
+            const SizedBox(height: 30),
+            const Text(
+              'Chat 4',
+              style: TextStyle(fontSize: 20),
+            ),
+            const SizedBox(height: 30),
+            const Text(
+              'Chat 5',
+              style: TextStyle(fontSize: 20),
+            ),
+          ],
+        ),
+      ),
+      bottomNavigationBar: NavBar(),
+    );
+  }
+}

--- a/lib/Views/myChats.dart
+++ b/lib/Views/myChats.dart
@@ -47,7 +47,7 @@ class MyChats extends StatelessWidget {
           ],
         ),
       ),
-      bottomNavigationBar: NavBar(),
+      bottomNavigationBar: NavBar(tab: 2),
     );
   }
 }

--- a/lib/Views/myProfile.dart
+++ b/lib/Views/myProfile.dart
@@ -1,0 +1,52 @@
+//View for the user's profile
+
+import 'package:flutter/material.dart';
+import 'package:roommatch/Widgets/navBar.dart';
+
+class MyProfile extends StatelessWidget {
+  const MyProfile({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      //appBar: AppBar(title: const Text('My Profile')),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            const Text(
+              'My Profile',
+              style: TextStyle(fontSize: 40),
+            ),
+            const SizedBox(height: 30),
+            const Text(
+              'Name: ',
+              style: TextStyle(fontSize: 20),
+            ),
+            const SizedBox(height: 30),
+            const Text(
+              'Age: ',
+              style: TextStyle(fontSize: 20),
+            ),
+            const SizedBox(height: 30),
+            const Text(
+              'College: ',
+              style: TextStyle(fontSize: 20),
+            ),
+            const SizedBox(height: 30),
+            const Text(
+              'Bio: ',
+              style: TextStyle(fontSize: 20),
+            ),
+            const SizedBox(height: 30),
+            const Text(
+              'Images: ',
+              style: TextStyle(fontSize: 20),
+            ),
+          ],
+        ),
+      ),
+      bottomNavigationBar: NavBar(),
+    );
+  }
+}

--- a/lib/Views/myProfile.dart
+++ b/lib/Views/myProfile.dart
@@ -9,15 +9,18 @@ class MyProfile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      //appBar: AppBar(title: const Text('My Profile')),
+      appBar: AppBar(
+          title: const Text('My Profile'), automaticallyImplyLeading: false),
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
+            const SizedBox(height: 30),
             const Text(
-              'My Profile',
-              style: TextStyle(fontSize: 40),
+              'Images: ',
+              style: TextStyle(fontSize: 20),
             ),
+            const Padding(padding: EdgeInsets.all(50)),
             const SizedBox(height: 30),
             const Text(
               'Name: ',
@@ -30,7 +33,7 @@ class MyProfile extends StatelessWidget {
             ),
             const SizedBox(height: 30),
             const Text(
-              'College: ',
+              'Institution: ',
               style: TextStyle(fontSize: 20),
             ),
             const SizedBox(height: 30),
@@ -38,15 +41,10 @@ class MyProfile extends StatelessWidget {
               'Bio: ',
               style: TextStyle(fontSize: 20),
             ),
-            const SizedBox(height: 30),
-            const Text(
-              'Images: ',
-              style: TextStyle(fontSize: 20),
-            ),
           ],
         ),
       ),
-      bottomNavigationBar: NavBar(),
+      bottomNavigationBar: NavBarExpanded(tab: 0),
     );
   }
 }

--- a/lib/Views/swipeOnPpl.dart
+++ b/lib/Views/swipeOnPpl.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:roommatch/ViewModels/ListOfUsers.dart';
 import 'package:roommatch/Models/UnmatchedUserModel.dart';
 import 'package:flutter_card_swiper/flutter_card_swiper.dart';
+import 'package:roommatch/Widgets/navBar.dart';
 
 // REF: https://pub.dev/packages/flutter_card_swiper
 // Main page where users can swipe on one another -> swipe animation
@@ -57,6 +58,7 @@ class SwipeOnPpl extends StatelessWidget {
           ),
         ),
       ),
+      bottomNavigationBar: NavBar(),
     );
   }
 }

--- a/lib/Views/swipeOnPpl.dart
+++ b/lib/Views/swipeOnPpl.dart
@@ -58,7 +58,7 @@ class SwipeOnPpl extends StatelessWidget {
           ),
         ),
       ),
-      bottomNavigationBar: NavBar(),
+      bottomNavigationBar: NavBar(tab: 1),
     );
   }
 }

--- a/lib/Views/userPreferences.dart
+++ b/lib/Views/userPreferences.dart
@@ -1,0 +1,50 @@
+//Simple skeleton view for the user's preferences
+
+import 'package:flutter/material.dart';
+
+class UserPreferences extends StatelessWidget {
+  const UserPreferences({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('User Preferences')),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            const Text(
+              'Preferences',
+              style: TextStyle(fontSize: 40),
+            ),
+            const SizedBox(height: 30),
+            const Text(
+              'Preference 1',
+              style: TextStyle(fontSize: 20),
+            ),
+            const SizedBox(height: 30),
+            const Text(
+              'Preference 2',
+              style: TextStyle(fontSize: 20),
+            ),
+            const SizedBox(height: 30),
+            const Text(
+              'Preference 3',
+              style: TextStyle(fontSize: 20),
+            ),
+            const SizedBox(height: 30),
+            const Text(
+              'Preference 4',
+              style: TextStyle(fontSize: 20),
+            ),
+            const SizedBox(height: 30),
+            const Text(
+              'Preference 5',
+              style: TextStyle(fontSize: 20),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/Widgets/navBar.dart
+++ b/lib/Widgets/navBar.dart
@@ -2,79 +2,14 @@ import 'package:flutter/material.dart';
 import 'package:roommatch/Views/myChats.dart';
 import 'package:roommatch/Views/myProfile.dart';
 import 'package:roommatch/Views/swipeOnPpl.dart';
+import 'package:roommatch/Views/userPreferences.dart';
+import 'package:roommatch/Views/appSettings.dart';
 
-void main() => runApp(const NavigationBarApp());
-
-class NavigationBarApp extends StatelessWidget {
-  const NavigationBarApp({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return const MaterialApp(home: NavigationExample());
-  }
-}
-
-class NavigationExample extends StatefulWidget {
-  const NavigationExample({super.key});
-
-  @override
-  State<NavigationExample> createState() => _NavigationExampleState();
-}
-
-class _NavigationExampleState extends State<NavigationExample> {
-  int currentPageIndex = 0;
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      bottomNavigationBar: NavigationBar(
-        onDestinationSelected: (int index) {
-          setState(() {
-            //Profile screen
-            if (currentPageIndex != 0 && index == 0) {
-              currentPageIndex = index;
-              Navigator.push(
-                context,
-                MaterialPageRoute(builder: (context) => MyProfile()),
-              );
-            } else if (currentPageIndex != 1 && index == 1) {
-              currentPageIndex = index;
-              Navigator.push(
-                context,
-                MaterialPageRoute(builder: (context) => SwipeOnPpl()),
-              );
-            } else if (currentPageIndex != 2 && index == 2) {
-              currentPageIndex = index;
-              Navigator.push(
-                context,
-                MaterialPageRoute(builder: (context) => MyChats()),
-              );
-            }
-          });
-        },
-        indicatorColor: Colors.amber[800],
-        selectedIndex: currentPageIndex,
-        destinations: const <Widget>[
-          NavigationDestination(
-            icon: Icon(Icons.person_sharp),
-            label: 'Profile',
-          ),
-          NavigationDestination(
-            icon: Icon(Icons.home),
-            label: 'Home',
-          ),
-          NavigationDestination(
-            icon: Icon(Icons.message_outlined),
-            label: 'Chats',
-          ),
-        ],
-      ),
-      //Upon pressing profile, it will take you to the profile page (myProfile.dart)
-      //Upon pressing home, it will take you to the home swipe page (swipeOnPpl.dart)
-      //Upon pressing chats, it will take you to the chats page (myChats.dart)
-    );
-  }
-}
+/*
+Generic NavBar widget that will fit as the bottomNavigationBar for several of our screens
+Has 3 sections: Profile, Home, and Chats
+Takes in one parameter (tab) so each screen is initialized with the correct option highlighted
+*/
 
 class NavBar extends StatefulWidget {
   const NavBar({super.key, required int tab});
@@ -84,7 +19,7 @@ class NavBar extends StatefulWidget {
 }
 
 class _NavBarState extends State<NavBar> {
-  int currentPageIndex = 0;
+  int currentPageIndex = 1;
 
   @override
   Widget build(BuildContext context) {
@@ -111,8 +46,8 @@ class _NavBarState extends State<NavBar> {
           }
         });
       },
-      indicatorColor: Colors.amber[800],
-      selectedIndex: currentPageIndex,
+      indicatorColor: Color.fromARGB(255, 34, 188, 222),
+      selectedIndex: widget.tab,
       destinations: const <Widget>[
         NavigationDestination(
           icon: Icon(Icons.person_sharp),
@@ -121,6 +56,86 @@ class _NavBarState extends State<NavBar> {
         NavigationDestination(
           icon: Icon(Icons.home),
           label: 'Home',
+        ),
+        NavigationDestination(
+          icon: Icon(Icons.message_outlined),
+          label: 'Chats',
+        ),
+      ],
+    );
+  }
+}
+
+/*
+Slightly altered NavBar for the Profile page, with options to open Preferences as well as Settings
+Has 5 sections: Profile, Preferences, Home, Settings, Chats
+Similarly takes in one parameter
+*/
+class NavBarExpanded extends StatefulWidget {
+  final int tab;
+
+  const NavBarExpanded({Key? key, required this.tab}) : super(key: key);
+
+  @override
+  State<NavBarExpanded> createState() => _NavBarExpandedState();
+}
+
+class _NavBarExpandedState extends State<NavBarExpanded> {
+  int currentPageIndex = 1;
+
+  @override
+  Widget build(BuildContext context) {
+    return NavigationBar(
+      onDestinationSelected: (int index) {
+        setState(() {
+          currentPageIndex = index;
+          //Profile screen
+          if (currentPageIndex == 0) {
+            Navigator.push(
+              context,
+              MaterialPageRoute(builder: (context) => MyProfile()),
+            );
+          } else if (currentPageIndex == 1) {
+            Navigator.push(
+              context,
+              MaterialPageRoute(builder: (context) => UserPreferences()),
+            );
+          } else if (currentPageIndex == 2) {
+            Navigator.push(
+              context,
+              MaterialPageRoute(builder: (context) => SwipeOnPpl()),
+            );
+          } else if (currentPageIndex == 3) {
+            Navigator.push(
+              context,
+              MaterialPageRoute(builder: (context) => AppSettings()),
+            );
+          } else if (currentPageIndex == 4) {
+            Navigator.push(
+              context,
+              MaterialPageRoute(builder: (context) => MyChats()),
+            );
+          }
+        });
+      },
+      indicatorColor: Color.fromARGB(255, 34, 188, 222),
+      selectedIndex: widget.tab,
+      destinations: const <Widget>[
+        NavigationDestination(
+          icon: Icon(Icons.person_sharp),
+          label: 'Profile',
+        ),
+        NavigationDestination(
+          icon: Icon(Icons.display_settings_sharp),
+          label: 'Preferences',
+        ),
+        NavigationDestination(
+          icon: Icon(Icons.home),
+          label: 'Home',
+        ),
+        NavigationDestination(
+          icon: Icon(Icons.settings),
+          label: 'Settings',
         ),
         NavigationDestination(
           icon: Icon(Icons.message_outlined),

--- a/lib/Widgets/navBar.dart
+++ b/lib/Widgets/navBar.dart
@@ -12,7 +12,8 @@ Takes in one parameter (tab) so each screen is initialized with the correct opti
 */
 
 class NavBar extends StatefulWidget {
-  const NavBar({super.key, required int tab});
+  final int tab;
+  const NavBar({super.key, required this.tab});
 
   @override
   State<NavBar> createState() => _NavBarState();

--- a/lib/Widgets/navBar.dart
+++ b/lib/Widgets/navBar.dart
@@ -1,4 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:roommatch/Views/myChats.dart';
+import 'package:roommatch/Views/myProfile.dart';
+import 'package:roommatch/Views/swipeOnPpl.dart';
 
 void main() => runApp(const NavigationBarApp());
 
@@ -27,45 +30,103 @@ class _NavigationExampleState extends State<NavigationExample> {
       bottomNavigationBar: NavigationBar(
         onDestinationSelected: (int index) {
           setState(() {
-            currentPageIndex = index;
+            //Profile screen
+            if (currentPageIndex != 0 && index == 0) {
+              currentPageIndex = index;
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) => MyProfile()),
+              );
+            } else if (currentPageIndex != 1 && index == 1) {
+              currentPageIndex = index;
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) => SwipeOnPpl()),
+              );
+            } else if (currentPageIndex != 2 && index == 2) {
+              currentPageIndex = index;
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) => MyChats()),
+              );
+            }
           });
         },
         indicatorColor: Colors.amber[800],
         selectedIndex: currentPageIndex,
         destinations: const <Widget>[
           NavigationDestination(
-            selectedIcon: Icon(Icons.home),
-            icon: Icon(Icons.home_outlined),
+            icon: Icon(Icons.person_sharp),
+            label: 'Profile',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.home),
             label: 'Home',
           ),
           NavigationDestination(
-            icon: Icon(Icons.business),
-            label: 'Business',
-          ),
-          NavigationDestination(
-            selectedIcon: Icon(Icons.school),
-            icon: Icon(Icons.school_outlined),
-            label: 'School',
+            icon: Icon(Icons.message_outlined),
+            label: 'Chats',
           ),
         ],
       ),
-      body: <Widget>[
-        Container(
-          color: Colors.red,
-          alignment: Alignment.center,
-          child: const Text('Page 1'),
+      //Upon pressing profile, it will take you to the profile page (myProfile.dart)
+      //Upon pressing home, it will take you to the home swipe page (swipeOnPpl.dart)
+      //Upon pressing chats, it will take you to the chats page (myChats.dart)
+    );
+  }
+}
+
+class NavBar extends StatefulWidget {
+  const NavBar({super.key});
+
+  @override
+  State<NavBar> createState() => _NavBarState();
+}
+
+class _NavBarState extends State<NavBar> {
+  int currentPageIndex = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return NavigationBar(
+      onDestinationSelected: (int index) {
+        setState(() {
+          currentPageIndex = index;
+          //Profile screen
+          if (currentPageIndex == 0) {
+            Navigator.push(
+              context,
+              MaterialPageRoute(builder: (context) => MyProfile()),
+            );
+          } else if (currentPageIndex == 1) {
+            Navigator.push(
+              context,
+              MaterialPageRoute(builder: (context) => SwipeOnPpl()),
+            );
+          } else if (currentPageIndex == 2) {
+            Navigator.push(
+              context,
+              MaterialPageRoute(builder: (context) => MyChats()),
+            );
+          }
+        });
+      },
+      indicatorColor: Colors.amber[800],
+      selectedIndex: currentPageIndex,
+      destinations: const <Widget>[
+        NavigationDestination(
+          icon: Icon(Icons.person_sharp),
+          label: 'Profile',
         ),
-        Container(
-          color: Colors.green,
-          alignment: Alignment.center,
-          child: const Text('Page 2'),
+        NavigationDestination(
+          icon: Icon(Icons.home),
+          label: 'Home',
         ),
-        Container(
-          color: Colors.blue,
-          alignment: Alignment.center,
-          child: const Text('Page 3'),
+        NavigationDestination(
+          icon: Icon(Icons.message_outlined),
+          label: 'Chats',
         ),
-      ][currentPageIndex],
+      ],
     );
   }
 }

--- a/lib/Widgets/navBar.dart
+++ b/lib/Widgets/navBar.dart
@@ -77,7 +77,7 @@ class _NavigationExampleState extends State<NavigationExample> {
 }
 
 class NavBar extends StatefulWidget {
-  const NavBar({super.key});
+  const NavBar({super.key, required int tab});
 
   @override
   State<NavBar> createState() => _NavBarState();


### PR DESCRIPTION
Added NavBar to home screen, profile screen, and chat screen:
- Clicking on the bar takes you to the corresponding screen
- Still pushes all routes to stack : is that necessary if the NavBar sticks around on all screens?

Added a usable NavBar widget inside of the navBar.dart widget file. Simply, it creates a NavigationBar widget pre-filled with the three main screen buttons. Can by used anywhere that NavigationBar is acceptable.